### PR TITLE
Remove version pins on xarray and dask

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -13,10 +13,10 @@ setuptools
 # Runtime dependencies:
 mpi4py
 python-dateutil
-xarray<0.8
+xarray
 netcdf4
 hdf4
-dask>=0.8.1
+dask
 
 # Testing dependencies:
 pytest


### PR DESCRIPTION
These are no longer required, the newest versions should work OK.