### PR TITLE
Update xarray import

### DIFF
--- a/scmtiles/runner.py
+++ b/scmtiles/runner.py
@@ -23,7 +23,7 @@ from os.path import join as pjoin
 import re
 from tempfile import mkdtemp
 
-import xray as xr
+import xarray as xr
 
 from .exceptions import TileInitializationError, TileRunError
 


### PR DESCRIPTION
Newer versions do not contain the xray module compatibility interface, use xarray instead.