### PR TITLE
Fixes for newer xarray versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The following dependencies are required to run scmtiles:
 
 * [mpi4py](http://mpi4py.readthedocs.io/)
 * [dateutil](https://dateutil.readthedocs.io/)
-* [xarray](http://xarray.pydata.org/en/v0.7.1/) < 0.8.0
+* [xarray](http://xarray.pydata.org/en/v0.7.1/)
 * [netcdf4](http://unidata.github.io/netcdf4-python/)
-* [dask](http://dask.pydata.org/) >= 0.8.1
+* [dask](http://dask.pydata.org/)
 * [versioneer](https://github.com/warner/python-versioneer)
 
 Once you have the dependencies installed you can install scmtiles with:

--- a/scmtiles/runner.py
+++ b/scmtiles/runner.py
@@ -23,7 +23,7 @@ from os.path import join as pjoin
 import re
 from tempfile import mkdtemp
 
-import xray as xr
+import xarray as xr
 
 from .exceptions import TileInitializationError, TileRunError
 
@@ -189,7 +189,7 @@ class TileRunner(metaclass=ABCMeta):
         if self.tile.type == 'linear':
             # Convert the grid coordinate back to latitude and longitude.
             # NB: cell_ds.unstack('grid') does not appear to work.
-            lat, lon = cell_ds['grid'].values
+            lat, lon = cell_ds['grid'].values.tolist()
             cell_ds.coords.update({self.config.yname: lat,
                                    self.config.xname: lon})
             cell_ds = cell_ds.drop('grid')


### PR DESCRIPTION
The changes are:
* xray compatibility module is removed
* need to use `tolist()` to properly unpack singleton coordinates
* update versions in README